### PR TITLE
Added 3 test parameters, betterworkflow, and fixed readme inconsistencies

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -19,7 +19,7 @@ Set the HTTP Headers for your template.
 
 Do a 301 redirect
 
-	{exp:http_header status="302" location="{path=site/something}" terminate="yes"}
+	{exp:http_header status="301" location="{path=site/something}" terminate="yes"}
 
 Set a 404 Status header
 
@@ -38,4 +38,3 @@ Test if the last_segment is the url_title and redirect if it is not
 
 For the above redirect, an additional segment (skip_betterworkflow) is needed if you are using better workflow
 {exp:http_header status="307" location="{path={segment_1}/{segment_2}/{url_title}}" terminate="yes" test_a="{segment_3}" test_type="!=" test_b="{url_title}" skip_betterworkflow="yes"}
-

--- a/system/expressionengine/third_party/http_header/pi.http_header.php
+++ b/system/expressionengine/third_party/http_header/pi.http_header.php
@@ -27,7 +27,7 @@ Set the HTTP Headers for your template.
 
 Do a 301 redirect
 
-	{exp:http_header status="302" location="{path=site/something}" terminate="yes"}
+	{exp:http_header status="301" location="{path=site/something}" terminate="yes"}
 
 Set a 404 Status header
 


### PR DESCRIPTION
I added 3 new parameters to allow more advanced conditionals to be processed.  (Because of how the addon works it always runs if you try to wrap it in an advanced conditional so this allows the addon to parse that data.)  Also, I added a parameter for it to skip doing the redirect on a betterworkflow draft.  I'm doing SEO optimization by redirecting all my /view/id urls to /view/url_title, but betterworkflow uses /view/id so I had to make it not redirect for betterworkflow to keep working.  I also fixed some readme inconsistencies between the readme file and the usage in the plugin file and fixed one bug with setting content type where it always read the parameter instead of using the charset variable.
