### PR TITLE
Adding X-Frame-Options header ability

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -14,6 +14,7 @@ Set the HTTP Headers for your template.
 * terminate - set to "yes" to prevent any other output from the template
 * vary - set a Vary header
 * access_control_allow_origin - set a Access-Control-Allow-Origin header
+* x_frame_options - set X-Frame-Options header to protect from clickjacking (control usage in iFrames)
 
 ## Examples
 
@@ -48,3 +49,9 @@ Set the Vary header to User-Agent
 Set the Access-Control-Allow-Origin header to allow all
 
     {exp:http_header access_control_allow_origin="*"}
+
+Set the X-Frame-Options header to a same website origin
+
+    {exp:http_header x_frame_options="SAMEORIGIN"}
+
+Options available for x_frame_options: DENY, SAMEORIGIN or ALLOW-FROM uri (replace uri for valid uri)

--- a/system/expressionengine/third_party/http_header/pi.http_header.php
+++ b/system/expressionengine/third_party/http_header/pi.http_header.php
@@ -95,6 +95,11 @@ class Http_header
 			$this->set_access_control_allow_origin($this->EE->TMPL->fetch_param('access_control_allow_origin'));
 		}
 
+        if ($this->EE->TMPL->fetch_param('x_frame_options') !== FALSE)
+        {
+            $this->set_x_frame_options($this->EE->TMPL->fetch_param('x_frame_options'));
+        }
+
 		if ($this->EE->TMPL->fetch_param('terminate') === 'yes')
 		{
 			foreach ($this->EE->output->headers as $header)
@@ -250,6 +255,24 @@ class Http_header
 	{
 		$this->EE->output->set_header('Access-Control-Allow-Origin: '.$header);
 	}
+
+    /**
+     * Set the X-Frame-Options header - prevents page from Clickjacking (control the site being used in iFrame)
+     * @param string $header
+     * ref: https://developer.mozilla.org/en-US/docs/Web/HTTP/X-Frame-Options
+     * EE ref: http://expressionengine.stackexchange.com/questions/26353/disable-x-frame-options-header-in-channel-form
+     */
+    protected function set_x_frame_options($header)
+    {
+        // Check Values passed
+        if (strtoupper($header) != "DENY"
+            && strtoupper($header) != "SAMEORIGIN"
+            && strtoupper(substr($header,0,10)) != "ALLOW-FROM") {
+            // Default
+            $header = "SAMEORIGIN";
+        }
+        $this->EE->output->set_header('X-Frame-Options: '.$header);
+    }
 }
 
 /* End of file pi.http_header.php */


### PR DESCRIPTION
For increased security, especially to prevent [clickjacking](http://en.wikipedia.org/wiki/clickjacking) it's recommended to set the [X-Frame-Options](https://developer.mozilla.org/en-US/docs/Web/HTTP/X-Frame-Options) header.

New parameter added: x_frame_options
Valid options are: DENY, SAMEORIGIN or ALLOW-FROM uri

If the parameter is passed but value does not match the options above, it defaults to SAMEORIGIN.